### PR TITLE
cloud: use GET instead of POST for fetching latest tilt version

### DIFF
--- a/internal/cloud/cloud_status_manager.go
+++ b/internal/cloud/cloud_status_manager.go
@@ -81,7 +81,7 @@ func (c *CloudStatusManager) CheckStatus(ctx context.Context, st store.RStore, c
 	u.Path = "/api/whoami"
 
 	body := &bytes.Buffer{}
-	req, err := http.NewRequest("POST", u.String(), body)
+	req, err := http.NewRequest("GET", u.String(), body)
 	if err != nil {
 		logger.Get(ctx).Debugf("error making whoami request: %v", err)
 		c.error()


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/whoami:

ae8d9151e4cc16a3eda8c9cda91bcdcd53e06cfc (2023-08-30 17:40:00 -0400)
cloud: use GET instead of POST for fetching latest tilt version
this should make it slightly easier to replace this endpoint with cloudfront

Signed-off-by: Nick Santos <nick.santos@docker.com>

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics